### PR TITLE
Fix error to pull invoices properly

### DIFF
--- a/src/CashierToolController.php
+++ b/src/CashierToolController.php
@@ -70,7 +70,7 @@
             return response()->json([
                 'user'          => $billable->toArray(),
                 'cards'         => request('brief') ? [] : $this->formatCards($billable),
-                'invoices'      => request('brief') ? [] : $this->formatInvoices(optional($billable->invoicesIncludingPending())->get()),
+                'invoices'      => request('brief') ? [] : $this->formatInvoices(optional($billable->invoicesIncludingPending())->toArray()),
                 'charges'       => request('brief') ? [] : $this->formatCharges($billable),
                 'subscriptions' => request()->has('subscription_id') ? $this->formatSubscription($subscription) : $this->formatSubscriptions($subscriptions),
                 'plans'         => request('brief') ? [] : $this->formatPlans(Plan::all()),


### PR DESCRIPTION
Too few arguments to function Illuminate\Support\Collection::get(), 0 passed in /var/www/vendor/laravel/framework/src/Illuminate/Support/Optional.php on line 127 and at least 1 expected